### PR TITLE
feat: add releases for docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 on: [workflow_dispatch]
 
+env:
+  IMAGE_NAME: atlas-ansible-utils
+
 jobs:
   bumpversion:
     runs-on: ubuntu-latest
@@ -60,3 +63,22 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
+
+  build_and_push:
+    needs: bumpversion
+    if: needs.bumpversion.outputs.version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ednxops/${{ env.IMAGE_NAME }}:${{ needs.bumpversion.outputs.version }}


### PR DESCRIPTION
## Description

Included in workflow releases for docker image provisioning databases, includes push to docker hub ednxops/atlas-ansible-utils repository

¡Warning! This pull request should only be closed when this [pull request](https://github.com/eduNEXT/atlas-ansible-utils/pull/5) is already closed.
