### PR TITLE
fix: update package cache when installing dependencies

### DIFF
--- a/roles/mysql_5_7/tasks/main.yml
+++ b/roles/mysql_5_7/tasks/main.yml
@@ -8,6 +8,7 @@
   apt:
     name: "{{ mysql_5_7_debian_pkgs }}"
     install_recommends: yes
+    update_cache: yes
     state: present
 
 - name: add the mysql signing key


### PR DESCRIPTION
# Description

While runing the `mysql_5_7.yml` playbook on a new machine some packages may appear missing due to a stale apt cache. This changes ensures that the cache is updated when installing dependencies.
