### PR TITLE
fix: set maxmemory-policy to allkeys-lru

### DIFF
--- a/roles/redis_6_2/defaults/main.yml
+++ b/roles/redis_6_2/defaults/main.yml
@@ -14,7 +14,7 @@ REDIS_PASSWORD: !!null
 REDIS_BIND_IP: 127.0.0.1
 REDIS_PERSISTENCE_DIR: "/var/lib/redis"
 REDIS_MEMORY_LIMIT: "512mb"
-REDIS_MAX_MEMORY_POLICY: "noeviction"
+REDIS_MAX_MEMORY_POLICY: "allkeys-lru"
 #
 # vars are namespace with the module name.
 #


### PR DESCRIPTION
### Description

Sets the `maxmemory-policy` default value to `allkeys-lru`.

No other change is required at the moment for this to work.