### PR TITLE
fix: update apt key for mysql

### DIFF
--- a/roles/mysql_5_7/defaults/main.yml
+++ b/roles/mysql_5_7/defaults/main.yml
@@ -10,7 +10,7 @@ mysql_community_server_5_7_pkg: "mysql-server=5.7.*"
 mysql_5_7_socket: /var/run/mysqld/mysqld.sock
 
 MYSQL_5_7_APT_KEYSERVER: "keyserver.ubuntu.com"
-MYSQL_5_7_APT_KEY: "467B942D3A79BD29"
+MYSQL_5_7_APT_KEY: "A8D3785C"
 MYSQL_5_7_REPO: "deb http://repo.mysql.com/apt//ubuntu/ bionic mysql-5.7"
 
 MYSQL_5_7_SUPPORTED_DISTRIBUTIONS:

--- a/roles/mysql_8_0/defaults/main.yml
+++ b/roles/mysql_8_0/defaults/main.yml
@@ -10,7 +10,7 @@ mysql_community_server_8_0_pkg: "mysql-server=8.0.*"
 mysql_8_0_socket: /var/run/mysqld/mysqld.sock
 
 MYSQL_8_0_APT_KEYSERVER: "keyserver.ubuntu.com"
-MYSQL_8_0_APT_KEY: "467B942D3A79BD29"
+MYSQL_8_0_APT_KEY: "A8D3785C"
 MYSQL_8_0_REPO: "deb http://repo.mysql.com/apt//ubuntu/ {{ ansible_distribution_release }} mysql-8.0"
 
 MYSQL_8_0_SUPPORTED_DISTRIBUTIONS:


### PR DESCRIPTION
# Description:
This PR corrects the [error with the APT key](https://bugs.mysql.com/bug.php?id=113427) that prevents provisioning mysql databases.
To fix the error, the apt key was updated with a  [new apt key](https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html#:~:text=new%20replacement%20key%20(-,A8D3785C,-)%20will%20sign%20upcoming)

## How to test it?
To test the Ansible Playbooks and provision databases you can use [these instructions](https://github.com/eduNEXT/atlas-ansible-utils?tab=readme-ov-file#atlas-ansible-utils)
It was successfully tried for mysql5.7 and 8.0 in Ubuntu 20 and 22