### PR TITLE
fix: verify that the content of the variable defining the suffix contains characters

### DIFF
--- a/roles/mongo_clone/tasks/clone.yml
+++ b/roles/mongo_clone/tasks/clone.yml
@@ -1,8 +1,8 @@
 ---
-- name: Verify if the suffix for database cloning is valid
+- name: Check if the suffix for database cloning is non-empty
   fail:
     msg: "The variable MONGO_CLONE_RESTORE_SUFFIX must be defined and contain a meaningful suffix so that the cloned databases names are not the same as the source databases names."
-  when: "MONGO_CLONE_RESTORE_SUFFIX is not defined or MONGO_CLONE_RESTORE_SUFFIX | trim == ''"
+  when: MONGO_CLONE_RESTORE_SUFFIX is not defined or MONGO_CLONE_RESTORE_SUFFIX | trim == ''
 
 - name: Extract Mongo backup from database {{ item }}
   include_role:

--- a/roles/mysql_clone/tasks/clone.yml
+++ b/roles/mysql_clone/tasks/clone.yml
@@ -1,8 +1,8 @@
 ---
-- name: Verify if the suffix for database cloning is valid
+- name: Check if the suffix for database cloning is non-empty
   fail:
     msg: "The variable MYSQL_CLONE_RESTORE_SUFFIX must be defined and contain a meaningful suffix so that the cloned databases names are not the same as the source databases names."
-  when: "MYSQL_CLONE_RESTORE_SUFFIX is not defined or MYSQL_CLONE_RESTORE_SUFFIX | trim == ''"
+  when: MYSQL_CLONE_RESTORE_SUFFIX is not defined or MYSQL_CLONE_RESTORE_SUFFIX | trim == ''
 
 - name: Extract MySQL backup from database {{ item }}
   include_role:


### PR DESCRIPTION
# Description:
This PR adds validation to roles that clone databases to fail when the variables controlling the suffix of the destination database are either undefined, empty `("")` or only contain spaces `(" ")`.