### PR TITLE
fix: use default auth plugin in mysql8

### DIFF
--- a/roles/mysql_8_0/tasks/main.yml
+++ b/roles/mysql_8_0/tasks/main.yml
@@ -59,9 +59,9 @@
     - localhost
     - "{{ ansible_hostname }}"
 
-- name: Alter user root to use mysql_native_password
+- name: Alter user root to use caching_sha2_password
   shell:
-    mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password; SET PASSWORD='';"
+    mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password; SET PASSWORD='';"
   become: true
 
 - name: Post MySQL installation configuration


### PR DESCRIPTION
# Description:
This PR change auth plugin for caching_sha2_password, [recommended for Mysql 8.0](https://dev.mysql.com/doc/refman/8.0/en/native-pluggable-authentication.html#:~:text=As%20of%20MySQL%208.0.34%2C%20the%20mysql_native_password%20authentication%20plugin%20is%20deprecated%20and%20subject%20to%20removal%20in%20a%20future%20version%20of%20MySQL)