### PR TITLE
chore: run molecule on ubuntu 22.04

### DIFF
--- a/molecule/clickhouse/molecule.yml
+++ b/molecule/clickhouse/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: clickhouse-instance
-    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/elasticsearch_7_10/molecule.yml
+++ b/molecule/elasticsearch_7_10/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: elasticsearch-instance
-    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/redis_6_2/molecule.yml
+++ b/molecule/redis_6_2/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: redis-6-2-instance
-    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw


### PR DESCRIPTION
### Description

This PR updates the molecule docker image to use ubuntu 22.04

**Note:** Old services are not updated as they will not be installed on those ubuntu versions.