### PR TITLE
docs: update elasticsearch on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following is the list of supported operating systems.
 | redis_7            |      x       |              |
 | mysql_8_4          |      x       |       x      |
 | mongo_7_0          |      x       |              |
-| elasticsearch_7    |      x       |              |
+| elasticsearch_7    |      x       |       x      |
 | clickhouse         |      x       |              |
 
 ## How to use this repo


### PR DESCRIPTION
# Description

This PR adds to docs the elasticsearch support merged [here](https://github.com/eduNEXT/atlas-ansible-utils/pull/49)