### PR TITLE
feat: use a custom network for docker databases

### DIFF
--- a/roles/docker_mongo/defaults/main.yml
+++ b/roles/docker_mongo/defaults/main.yml
@@ -19,4 +19,9 @@ DOCKER_MONGO_PORT: 27017
 #   fstype: xfs
 #   size: "50.00 GB"
 
+# Name of the network used by the containers. User created networks allow
+# containers to communicate using Docker's Name resolution (i.e. using the
+# container name as the hostname).
+DOCKER_MONGO_NETWORK: databases
+
 mongo_extra_conf: ""

--- a/roles/docker_mongo/tasks/main.yml
+++ b/roles/docker_mongo/tasks/main.yml
@@ -28,6 +28,13 @@
     and DOCKER_MONGO_VOLUME.device is defined
     and DOCKER_MONGO_VOLUME.fstype is defined
 
+- name: Configure MongoDB Network
+  community.docker.docker_network:
+    name: "{{ DOCKER_MONGO_NETWORK }}"
+  tags:
+    - mongo
+    - network
+
 - name: Configure MongoDB Volumes in {{ DOCKER_MONGO_VOLUME.device }}
   community.docker.docker_volume:
     volume_name: mongo-data
@@ -86,6 +93,8 @@
     name: mongo
     image: "{{ DOCKER_MONGO_IMAGE }}"
     restart_policy: unless-stopped
+    networks:
+      - name: "{{ DOCKER_MONGO_NETWORK }}"
     command:
       - --config
       - /etc/mongod.conf

--- a/roles/docker_mysql/defaults/main.yml
+++ b/roles/docker_mysql/defaults/main.yml
@@ -8,6 +8,11 @@ DOCKER_MYSQL_IMAGE: docker.io/mysql:8.4.0
 DOCKER_MYSQL_BIND_ADDRESS: 0.0.0.0
 DOCKER_MYSQL_PORT: 3306
 
+# Name of the network used by the containers. User created networks allow
+# containers to communicate using Docker's Name resolution (i.e. using the
+# container name as the hostname).
+DOCKER_MYSQL_NETWORK: databases
+
 MYSQL_CONFIG_SERVER_ID: 1
 MYSQL_CONFIG_READ_ONLY: "OFF"
 MYSQL_CONFIG_CHARACTER_SET_SERVER: utf8mb4

--- a/roles/docker_mysql/tasks/main.yml
+++ b/roles/docker_mysql/tasks/main.yml
@@ -94,11 +94,20 @@
   notify:
     - Restart MySQL Container
 
+- name: Configure MySQL Network
+  community.docker.docker_network:
+    name: "{{ DOCKER_MYSQL_NETWORK }}"
+  tags:
+    - mysql
+    - network
+
 - name: Start MySQL Container
   community.docker.docker_container:
     name: mysql
     image: "{{ DOCKER_MYSQL_IMAGE }}"
     restart_policy: unless-stopped
+    networks:
+      - name: "{{ DOCKER_MYSQL_NETWORK }}"
     state: started
     published_ports:
       - "{{  DOCKER_MYSQL_BIND_ADDRESS }}:{{ DOCKER_MYSQL_PORT }}:3306"


### PR DESCRIPTION

The main advantage of running the containers in a user defined network is that they have access to the name resolution service provided by docker. This allows containers to refer to each other by container name instead of IP, this is particularly useful when running external container that wants to connect to the DBs (e.g. running a MySQL client in a separate container).