### PR TITLE
feat: add caddy health checks

### DIFF
--- a/molecule/caddy/molecule.yml
+++ b/molecule/caddy/molecule.yml
@@ -20,6 +20,17 @@ platforms:
 provisioner:
   name: ansible
   inventory:
-    all: {}
+    group_vars:
+      all:
+        caddy_backend_targets:
+        - 'localhost:8080'
+        # This emulates a bad node: curl: (7) Failed to connect to localhost port 8082 after 0 ms: Connection refused
+        - 'localhost:8082'
+        # This emulates a host which proxies 8080 and 8082
+        caddy_extra_rules: |
+          :8081 {
+            import https-proxy {{caddy_backend_targets|join(' ')}}
+          }
+
 verifier:
   name: ansible

--- a/molecule/caddy/verify.yml
+++ b/molecule/caddy/verify.yml
@@ -9,3 +9,13 @@
     register: caddy
     shell: |
       caddy version
+      curl -I http://localhost:8080 -f -s # Make sure we receive responses from :8080
+      curl -I http://localhost:8081 -f -s # Make sure we receive responses instead of timeouts
+      curl -I http://localhost:8081 -f -s # Make sure we receive responses instead of timeouts
+      curl -I http://localhost:8082 -f -s -m 2
+      if [ $? -ne 0 ]; then
+        echo "Can't connect to :8082 but :8081 is still alive"
+        exit 0
+      else
+        exit 1
+      fi

--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -27,3 +27,5 @@ caddy_backend_target:
 caddy_global_options: |
   # Additional caddy global options
   # See https://caddyserver.com/docs/caddyfile/options for more information
+
+caddy_health_uri: /healthz

--- a/roles/caddy/templates/Caddyfile.j2
+++ b/roles/caddy/templates/Caddyfile.j2
@@ -13,6 +13,9 @@ respond "Hello, world!"
     reverse_proxy {
         to {args[:]}
         lb_policy round_robin
+
+        health_timeout 5s
+        health_uri {{ caddy_health_uri }}
     }
 }
 


### PR DESCRIPTION
### Description

This PR adds port health checks for each proxy:

#### Before
It keeps waiting for a response:
![image](https://github.com/user-attachments/assets/30f3a568-ea5b-48b7-86b8-26d35b6ed7ad)

#### After
503 response after `health_timeout` (`10s`):
![image](https://github.com/user-attachments/assets/bb99097b-d99d-4107-83ba-ef3be3ede8a1)
