### PR TITLE
feat: add haproxy docker role

### DIFF
--- a/playbooks/docker_haproxy.yml
+++ b/playbooks/docker_haproxy.yml
@@ -1,0 +1,7 @@
+---
+- name: Deploy HAProxy in Docker containers
+  hosts: haproxy_servers
+  gather_facts: true
+  become: false
+  roles:
+    - role: docker_haproxy

--- a/roles/docker_haproxy/defaults/main.yml
+++ b/roles/docker_haproxy/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+DOCKER_HAPROXY_IMAGE: docker.io/haproxy:3.1
+
+# Bind adress and ports exposed by the docker container.
+# We keep the default port and bind address inside the container and instead
+# configure the address and port used by the host using the docker port mapping
+# feature.
+DOCKER_HAPROXY_BIND_ADDRESS: 0.0.0.0
+
+# Name of the network used by the containers. User created networks allow
+# containers to communicate using Docker's Name resolution (i.e. using the
+# container name as the hostname).
+DOCKER_HAPROXY_NETWORK: proxy
+
+DOCKER_HAPROXY_BACKENDS: []
+
+DOCKER_HAPROXY_HTTP_PORT: 32080
+DOCKER_HAPROXY_HTTPS_PORT: 32443

--- a/roles/docker_haproxy/handlers/main.yml
+++ b/roles/docker_haproxy/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart HAProxy Container
+  community.docker.docker_container:
+    name: haproxy
+    state: started
+    restart: true

--- a/roles/docker_haproxy/meta/main.yml
+++ b/roles/docker_haproxy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: docker_install

--- a/roles/docker_haproxy/tasks/main.yml
+++ b/roles/docker_haproxy/tasks/main.yml
@@ -30,7 +30,6 @@
     published_ports:
       - "{{ DOCKER_HAPROXY_BIND_ADDRESS }}:80:80"
       - "{{ DOCKER_HAPROXY_BIND_ADDRESS }}:443:443"
-      - "{{ DOCKER_HAPROXY_BIND_ADDRESS }}:8404:8404"
     mounts:
       - source: /etc/haproxy/
         target: /usr/local/etc/haproxy

--- a/roles/docker_haproxy/tasks/main.yml
+++ b/roles/docker_haproxy/tasks/main.yml
@@ -1,0 +1,40 @@
+- name: Render HAProxy configuration
+  become: true
+  ansible.builtin.template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0644"
+  tags:
+    - haproxy
+    - config
+  notify:
+    - Restart HAProxy Container
+
+- name: Configure HAProxy Network
+  community.docker.docker_network:
+    name: "{{ DOCKER_HAPROXY_NETWORK }}"
+  tags:
+    - docker
+    - network
+
+- name: Start HAProxy Container
+  community.docker.docker_container:
+    name: haproxy
+    image: "{{ DOCKER_HAPROXY_IMAGE }}"
+    restart_policy: unless-stopped
+    networks:
+      - name: "{{ DOCKER_HAPROXY_NETWORK }}"
+    state: started
+    published_ports:
+      - "{{ DOCKER_HAPROXY_BIND_ADDRESS }}:80:80"
+      - "{{ DOCKER_HAPROXY_BIND_ADDRESS }}:443:443"
+      - "{{ DOCKER_HAPROXY_BIND_ADDRESS }}:8404:8404"
+    mounts:
+      - source: /etc/haproxy/
+        target: /usr/local/etc/haproxy
+        type: bind
+  tags:
+    - haproxy
+    - container

--- a/roles/docker_haproxy/templates/haproxy.cfg.j2
+++ b/roles/docker_haproxy/templates/haproxy.cfg.j2
@@ -44,8 +44,8 @@ frontend https
   default_backend https_k8s_servers
   mode tcp
 
-frontend stats
-  bind *:8404
-  stats enable
-  stats uri /
-  stats refresh 10s
+# frontend stats
+#   bind *:8404
+#   stats enable
+#   stats uri /
+#   stats refresh 10s

--- a/roles/docker_haproxy/templates/haproxy.cfg.j2
+++ b/roles/docker_haproxy/templates/haproxy.cfg.j2
@@ -1,0 +1,51 @@
+global
+  # stats socket /var/run/api.sock user haproxy group haproxy mode 660 level admin expose-fd listeners
+  log stdout format raw local0 info
+
+  # Default SSL material locations
+  ca-base /etc/ssl/certs
+  crt-base /etc/ssl/private
+
+  # See: https://ssl-config.mozilla.org/#server=haproxy&server-version=2.0.3&config=intermediate
+  ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+
+defaults
+  log     global
+  mode    http
+  option  httplog
+  option  dontlognull
+  timeout connect 5000
+  timeout client  50000
+  timeout server  50000
+
+backend http_k8s_servers
+  balance roundrobin
+  {% for backend in DOCKER_HAPROXY_BACKENDS %}
+  server s1 {{backend}}:{{DOCKER_HAPROXY_HTTP_PORT}} check send-proxy
+  {% endfor %}
+  mode tcp
+
+backend https_k8s_servers
+  balance roundrobin
+  {% for backend in DOCKER_HAPROXY_BACKENDS %}
+  server s1 {{backend}}:{{DOCKER_HAPROXY_HTTPS_PORT}} check send-proxy
+  {% endfor %}
+  mode tcp
+
+frontend http
+  bind *:80
+  default_backend http_k8s_servers
+  mode tcp
+
+frontend https
+  bind *:443
+  default_backend https_k8s_servers
+  mode tcp
+
+frontend stats
+  bind *:8404
+  stats enable
+  stats uri /
+  stats refresh 10s


### PR DESCRIPTION
### Description

This PR adds a role to install haproxy on docker as a replacement for Caddy.