### PR TITLE
fix: use ip hash as load balancing algorithm

### DIFF
--- a/roles/docker_haproxy/templates/haproxy.cfg.j2
+++ b/roles/docker_haproxy/templates/haproxy.cfg.j2
@@ -21,14 +21,14 @@ defaults
   timeout server  50000
 
 backend http_k8s_servers
-  balance roundrobin
+  balance source
   {% for backend in DOCKER_HAPROXY_BACKENDS %}
   server s1 {{backend}}:{{DOCKER_HAPROXY_HTTP_PORT}} check send-proxy
   {% endfor %}
   mode tcp
 
 backend https_k8s_servers
-  balance roundrobin
+  balance source
   {% for backend in DOCKER_HAPROXY_BACKENDS %}
   server s1 {{backend}}:{{DOCKER_HAPROXY_HTTPS_PORT}} check send-proxy
   {% endfor %}


### PR DESCRIPTION
This PR updates the load balancing algorithm to `source` (equivalent to ip_hash on nginx).

See https://www.haproxy.com/documentation/haproxy-configuration-tutorials/core-concepts/backends/#change-the-load-balancing-algorithm