### PR TITLE
fix(roles): added ignore to pep 668 in backups playbooks

### DIFF
--- a/charts/ansible-runner/Chart.yaml
+++ b/charts/ansible-runner/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ansible-runner
 description: Kubernetes jobs to execute ansible playbooks
 type: application
-version: 19.1.0
-appVersion: 19.1.0
+version: 19.0.1
+appVersion: 19.0.1

--- a/charts/ansible-runner/Chart.yaml
+++ b/charts/ansible-runner/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ansible-runner
 description: Kubernetes jobs to execute ansible playbooks
 type: application
-version: 19.0.0
-appVersion: 19.0.0
+version: 19.1.0
+appVersion: 19.1.0

--- a/roles/mongo_7_0/tasks/main.yml
+++ b/roles/mongo_7_0/tasks/main.yml
@@ -18,6 +18,8 @@
     state: present
     update_cache: true
 
+# Since ubuntu 24/Debian 12 have problems with the backup playbook because of PEP 668 when updating the libraries, we proceed
+# to create a task to ignore EXTERNALLY-MANAGED
 - name: Get python system info
   community.general.python_requirements_info:
   register: python_info
@@ -27,7 +29,6 @@
     path: "/usr/lib/python{{ python_info.python_version_info.major }}.{{ python_info.python_version_info.minor }}/EXTERNALLY-MANAGED"
     state: absent
   when:
-    # Condition for Ubuntu 24.04+ or Debian 12+
     - (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')) or
       (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
 

--- a/roles/mongo_7_0/tasks/main.yml
+++ b/roles/mongo_7_0/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python}}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{python_info.python_version_info.major}}.{{python_info.python_version_info.minor}}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_7_0/tasks/main.yml
+++ b/roles/mongo_7_0/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{python_info.python_version_info.major}}.{{python_info.python_version_info.minor}}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python_version_info.major }}.{{ python_info.python_version_info.minor }}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_7_0/tasks/main.yml
+++ b/roles/mongo_7_0/tasks/main.yml
@@ -18,11 +18,18 @@
     state: present
     update_cache: true
 
-- name: Ignore PEP 668
+- name: Get python system info
+  community.general.python_requirements_info:
+  register: python_info
+
+- name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: /usr/lib/python3.12/EXTERNALLY-MANAGED
+    path: "/usr/lib/python{{ python_info.python.version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
     state: absent
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')
+  when:
+    # Condition for Ubuntu 24.04+ or Debian 12+
+    - (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')) or
+      (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
 
 - name: Install python pymongo for mongo_user ansible module
   ansible.builtin.pip:

--- a/roles/mongo_7_0/tasks/main.yml
+++ b/roles/mongo_7_0/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python_version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python}}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_7_0/tasks/main.yml
+++ b/roles/mongo_7_0/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python.version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python_version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_backup/tasks/main.yml
+++ b/roles/mongo_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python.version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python_version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_backup/tasks/main.yml
+++ b/roles/mongo_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python_version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python}}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_backup/tasks/main.yml
+++ b/roles/mongo_backup/tasks/main.yml
@@ -9,11 +9,20 @@
     and mongo_artifact_path != ""
     and MONGO_BACKUP_STORAGE_OPTIONS.EXTERNAL_STORAGE_TYPE != ""
 
-- name: Ignore PEP 668
+# Since ubuntu 24 has problems with the backup playbook because of PEP 668 when updating the libraries, we proceed
+# to create a task to ignore EXTERNALLY-MANAGED
+- name: Get python system info
+  community.general.python_requirements_info:
+  register: python_info
+
+- name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: /usr/lib/python3.12/EXTERNALLY-MANAGED
+    path: "/usr/lib/python{{ python_info.python.version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
     state: absent
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')
+  when:
+    # Condition for Ubuntu 24.04+ or Debian 12+
+    - (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')) or
+      (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
 
 - name: Launch Mongo Backups
   ansible.builtin.include_tasks: backup.yml

--- a/roles/mongo_backup/tasks/main.yml
+++ b/roles/mongo_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{python_info.python_version_info.major}}.{{python_info.python_version_info.minor}}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python_version_info.major }}.{{ python_info.python_version_info.minor }}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_backup/tasks/main.yml
+++ b/roles/mongo_backup/tasks/main.yml
@@ -9,6 +9,12 @@
     and mongo_artifact_path != ""
     and MONGO_BACKUP_STORAGE_OPTIONS.EXTERNAL_STORAGE_TYPE != ""
 
+- name: Ignore PEP 668
+  ansible.builtin.file:
+    path: /usr/lib/python3.12/EXTERNALLY-MANAGED
+    state: absent
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')
+
 - name: Launch Mongo Backups
   ansible.builtin.include_tasks: backup.yml
 - name: Clean artifact path

--- a/roles/mongo_backup/tasks/main.yml
+++ b/roles/mongo_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python}}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{python_info.python_version_info.major}}.{{python_info.python_version_info.minor}}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mongo_backup/tasks/main.yml
+++ b/roles/mongo_backup/tasks/main.yml
@@ -9,7 +9,7 @@
     and mongo_artifact_path != ""
     and MONGO_BACKUP_STORAGE_OPTIONS.EXTERNAL_STORAGE_TYPE != ""
 
-# Since ubuntu 24 has problems with the backup playbook because of PEP 668 when updating the libraries, we proceed
+# Since ubuntu 24/Debian 12 have problems with the backup playbook because of PEP 668 when updating the libraries, we proceed
 # to create a task to ignore EXTERNALLY-MANAGED
 - name: Get python system info
   community.general.python_requirements_info:
@@ -20,7 +20,6 @@
     path: "/usr/lib/python{{ python_info.python_version_info.major }}.{{ python_info.python_version_info.minor }}/EXTERNALLY-MANAGED"
     state: absent
   when:
-    # Condition for Ubuntu 24.04+ or Debian 12+
     - (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')) or
       (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
 

--- a/roles/mysql_backup/tasks/main.yml
+++ b/roles/mysql_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python.version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python_version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mysql_backup/tasks/main.yml
+++ b/roles/mysql_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python_version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python}}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mysql_backup/tasks/main.yml
+++ b/roles/mysql_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{python_info.python_version_info.major}}.{{python_info.python_version_info.minor}}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{ python_info.python_version_info.major }}.{{ python_info.python_version_info.minor }}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mysql_backup/tasks/main.yml
+++ b/roles/mysql_backup/tasks/main.yml
@@ -9,11 +9,20 @@
     and mysql_artifact_path != ""
     and MYSQL_BACKUP_STORAGE_OPTIONS.EXTERNAL_STORAGE_TYPE != ""
 
-- name: Ignore PEP 668
+# Since ubuntu 24 has problems with the backup playbook because of PEP 668 when updating the libraries, we proceed
+# to create a task to ignore EXTERNALLY-MANAGED
+- name: Get python system info
+  community.general.python_requirements_info:
+  register: python_info
+
+- name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: /usr/lib/python3.12/EXTERNALLY-MANAGED
+    path: "/usr/lib/python{{ python_info.python.version | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}/EXTERNALLY-MANAGED"
     state: absent
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')
+  when:
+    # Condition for Ubuntu 24.04+ or Debian 12+
+    - (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')) or
+      (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
 
 - name: Launch MySQL Backups
   ansible.builtin.include_tasks: backup.yml

--- a/roles/mysql_backup/tasks/main.yml
+++ b/roles/mysql_backup/tasks/main.yml
@@ -9,6 +9,12 @@
     and mysql_artifact_path != ""
     and MYSQL_BACKUP_STORAGE_OPTIONS.EXTERNAL_STORAGE_TYPE != ""
 
+- name: Ignore PEP 668
+  ansible.builtin.file:
+    path: /usr/lib/python3.12/EXTERNALLY-MANAGED
+    state: absent
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')
+
 - name: Launch MySQL Backups
   ansible.builtin.include_tasks: backup.yml
 - name: Clean artifact path

--- a/roles/mysql_backup/tasks/main.yml
+++ b/roles/mysql_backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ignore PEP 668 (Ubuntu/Debian)
   ansible.builtin.file:
-    path: "/usr/lib/python{{ python_info.python}}/EXTERNALLY-MANAGED"
+    path: "/usr/lib/python{{python_info.python_version_info.major}}.{{python_info.python_version_info.minor}}/EXTERNALLY-MANAGED"
     state: absent
   when:
     # Condition for Ubuntu 24.04+ or Debian 12+

--- a/roles/mysql_backup/tasks/main.yml
+++ b/roles/mysql_backup/tasks/main.yml
@@ -9,7 +9,7 @@
     and mysql_artifact_path != ""
     and MYSQL_BACKUP_STORAGE_OPTIONS.EXTERNAL_STORAGE_TYPE != ""
 
-# Since ubuntu 24 has problems with the backup playbook because of PEP 668 when updating the libraries, we proceed
+# Since ubuntu 24/Debian 12 have problems with the backup playbook because of PEP 668 when updating the libraries, we proceed
 # to create a task to ignore EXTERNALLY-MANAGED
 - name: Get python system info
   community.general.python_requirements_info:
@@ -20,7 +20,6 @@
     path: "/usr/lib/python{{ python_info.python_version_info.major }}.{{ python_info.python_version_info.minor }}/EXTERNALLY-MANAGED"
     state: absent
   when:
-    # Condition for Ubuntu 24.04+ or Debian 12+
     - (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')) or
       (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
 


### PR DESCRIPTION
## Description
Added ignore of PEP 668. Issue [#359](https://github.com/orgs/eduNEXT/projects/44/views/1?pane=issue&itemId=120526760&issue=eduNEXT%7Catlas-backlog%7C359) 

## Tests performed
Since the Yamato servers (MySQL and MongoDB) run Ubuntu 22, the backup fix tests couldn't be performed there. The EXTERNALLY MANAGED feature is present starting from Ubuntu 23.04 and Debian 12. Therefore, it was decided to perform the test locally by creating Docker containers with Ubuntu 24 and MySQL.

## Results
Test performed without the fix from the task "Ignore PEP 668 (Ubuntu/Debian)":

<img width="1273" height="851" alt="Image" src="https://github.com/user-attachments/assets/98b0a14f-3f0f-4443-b974-b246fbf2536f" />
The Ansible logs show the Externally managed error caused by the task (added for testing purposes) running pip install request.

Test performed with the fix:

<img width="1249" height="593" alt="Image" src="https://github.com/user-attachments/assets/06f0849c-90a1-4061-b60c-58fc69ea782f" />
The pip install was executed without any apparent issues.

## Conclusion
With the following tasks:

``` yml
- name: Get python system info
  community.general.python_requirements_info:
  register: python_info

- name: Ignore PEP 668 (Ubuntu/Debian)
  ansible.builtin.file:
    path: "/usr/lib/python{{python_info.python_version_info.major}}.{{python_info.python_version_info.minor}}/EXTERNALLY-MANAGED"
    state: absent
  when:
    # Condition for Ubuntu 24.04+ or Debian 12+
    - (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('24', '>=')) or
      (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
```
PEP 668 can be ignored dynamically.

## NOTE
The same test was performed with the latest version of **Debian**, but no issues with EXTERNALLY-MANAGED were observed.
