### PR TITLE
feat: added node_exporter playbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,14 @@ jobs:
           echo "scenarios=$SCENARIOS" >> $GITHUB_OUTPUT
 
   tests:
+    needs: gather-tests
     if: ${{ needs.gather-tests.outputs.roles != '[]' && needs.gather-tests.outputs.roles != '' }}
     name: Run Molecule Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        environment: ${{ fromJson(needs.load-roles.outputs.roles) }}
+        environment: ${{ fromJson(needs.gather-tests.outputs.roles) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,7 +66,7 @@ jobs:
           version: ${{ env.UV_VERSION }}
           python-version: 3.12
       - name: Run molecule tests
-        if: ${{ contains(fromJson(needs.load-roles.outputs.scenarios), matrix.environment) }}
+        if: ${{ contains(fromJson(needs.gather-tests.outputs.scenarios), matrix.environment) }}
         run: uv run molecule test -s ${{ matrix.environment }}
         env:
           PY_COLORS: '1'

--- a/changelog.d/20260611_085007_moises.gonzalez_node_exporter.md
+++ b/changelog.d/20260611_085007_moises.gonzalez_node_exporter.md
@@ -1,0 +1,5 @@
+### Added
+
+- A new node_exporter role and playbook that installs Prometheus'
+  [node_exporter](https://github.com/prometheus/node_exporter) on Linux hosts.
+  node_exporter is ran and managed via a systemd unit service.

--- a/molecule/caddy/molecule.yml
+++ b/molecule/caddy/molecule.yml
@@ -47,5 +47,15 @@ provisioner:
             import https-proxy {{caddy_backend_targets|join(' ')}}
           }
 
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
+
 verifier:
   name: ansible

--- a/molecule/clickhouse/molecule.yml
+++ b/molecule/clickhouse/molecule.yml
@@ -37,5 +37,14 @@ provisioner:
   inventory:
     all:
       CLICKHOUSE_DEFAULT_USER_PASSWORD: password
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,16 @@
+---
+driver:
+  name: docker
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/mongo_7_0/molecule.yml
+++ b/molecule/mongo_7_0/molecule.yml
@@ -36,5 +36,14 @@ provisioner:
   name: ansible
   inventory:
     all: {}
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 verifier:
   name: ansible

--- a/molecule/mysql_8_4/molecule.yml
+++ b/molecule/mysql_8_4/molecule.yml
@@ -42,5 +42,14 @@ provisioner:
         password: password
         state: present
         append_privs: no
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 verifier:
   name: ansible

--- a/molecule/node_exporter/converge.yml
+++ b/molecule/node_exporter/converge.yml
@@ -1,0 +1,3 @@
+---
+- name: Converge
+  import_playbook: ../../playbooks/node_exporter.yml

--- a/molecule/node_exporter/molecule.yml
+++ b/molecule/node_exporter/molecule.yml
@@ -2,22 +2,7 @@
 driver:
   name: docker
 platforms:
-  - name: meilisearch-ubuntu2404
-    image: geerlingguy/docker-ubuntu2404-ansible:latest
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    capabilities:
-      - SYS_ADMIN
-    tmpfs:
-      - /run
-      - /tmp
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-    groups:
-      - meilisearch_servers
-  - name: meilisearch-ubuntu2204
+  - name: node_exporter-ubuntu2204
     image: geerlingguy/docker-ubuntu2204-ansible:latest
     command: ""
     volumes:
@@ -31,11 +16,24 @@ platforms:
     privileged: true
     pre_build_image: true
     groups:
-      - meilisearch_servers
+      - node_exporter_servers
+  - name: node_exporter-ubuntu2404
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    capabilities:
+      - SYS_ADMIN
+    tmpfs:
+      - /run
+      - /tmp
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+    groups:
+      - node_exporter_servers
 provisioner:
   name: ansible
-  inventory:
-    all: {}
 scenario:
   test_sequence:
     - destroy
@@ -45,5 +43,8 @@ scenario:
     - idempotence
     - verify
     - destroy
+  converge_sequence:
+    - create
+    - converge
 verifier:
   name: ansible

--- a/molecule/node_exporter/verify.yml
+++ b/molecule/node_exporter/verify.yml
@@ -1,0 +1,28 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Verify node_exporter binary exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/node_exporter
+      register: node_exporter_binary
+      failed_when: not node_exporter_binary.stat.exists
+
+    - name: Verify node_exporter service is running
+      ansible.builtin.service:
+        name: node_exporter
+        state: started
+
+    - name: Verify node_exporter socket is listening
+      ansible.builtin.wait_for:
+        port: 9100
+        state: started
+        timeout: 10
+
+    - name: Verify node_exporter metrics endpoint
+      ansible.builtin.uri:
+        url: http://localhost:9100/metrics
+        return_content: false
+      register: metrics
+      failed_when: metrics.status != 200

--- a/molecule/redis_7/molecule.yml
+++ b/molecule/redis_7/molecule.yml
@@ -36,5 +36,14 @@ provisioner:
   name: ansible
   inventory:
     all: {}
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 verifier:
   name: ansible

--- a/playbooks/node_exporter.yml
+++ b/playbooks/node_exporter.yml
@@ -1,0 +1,8 @@
+---
+# Install and configure node_exporter on DB hosts
+- name: Deploy node_exporter
+  hosts: node_exporter_servers
+  become: true
+  gather_facts: true
+  roles:
+    - role: node_exporter

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -1,0 +1,7 @@
+node_exporter_bin_path: "/usr/local/bin/"
+node_exporter_checksum: "sha256:9f5ea48e5bc7b656f8a91a32e7d7deb89f70f73dabd0d974418aca15f37d6810"  # Retrieved from the sha256sums.txt on the releases page
+node_exporter_listen_port: "9100"
+node_exporter_options: "--collector.textfile.directory {{ node_exporter_textfile_dir }}"
+node_exporter_release_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz"  # yamllint disable-line rule:line-length
+node_exporter_textfile_dir: "/var/lib/node_exporter/textfile_collector"
+node_exporter_version: "1.11.1"

--- a/roles/node_exporter/handlers/main.yml
+++ b/roles/node_exporter/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart node_exporter
+  ansible.builtin.service:
+    name: node_exporter
+    state: restarted

--- a/roles/node_exporter/tasks/main.yml
+++ b/roles/node_exporter/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+- name: "Check current node_exporter version"
+  ansible.builtin.command: "{{ node_exporter_bin_path }}/node_exporter --version"
+  failed_when: false
+  changed_when: false
+  register: node_exporter_current_version
+
+- name: "Download node_exporter archive"
+  ansible.builtin.get_url:
+    url: "{{ node_exporter_release_url }}"
+    dest: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
+    checksum: "{{ node_exporter_checksum }}"
+    mode: "0644"
+  when: >
+    node_exporter_current_version.stdout is not defined or node_exporter_version not in node_exporter_current_version.stdout
+
+- name: "Extract binary from archive into {{ node_exporter_bin_path }}"
+  ansible.builtin.unarchive:
+    src: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
+    include:
+      - "node_exporter-{{ node_exporter_version }}.linux-amd64/node_exporter"
+    dest: "{{ node_exporter_bin_path }}"
+    extra_opts:
+      - "--strip-components=1"
+    remote_src: true
+    mode: "0755"
+  notify: "Restart node_exporter"
+  when: >
+    node_exporter_current_version.stdout is not defined or node_exporter_version not in node_exporter_current_version.stdout
+
+- name: "Remove node_exporter archive"
+  ansible.builtin.file:
+    path: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
+    state: absent
+
+- name: Create node_exporter system group
+  ansible.builtin.group:
+    name: node_exporter
+    system: true
+    gid: "{{ node_exporter_gid | default(omit) }}"
+    state: present
+
+- name: Create node_exporter system user
+  ansible.builtin.user:
+    name: node_exporter
+    system: true
+    home: /var/lib/node_exporter
+    create_home: false
+    shell: /usr/sbin/nologin
+    uid: "{{ node_exporter_uid | default(omit) }}"
+    group: node_exporter
+    state: present
+
+- name: "Create node_exporter textfile collector directory"
+  ansible.builtin.file:
+    path: "{{ node_exporter_textfile_dir }}"
+    state: directory
+    owner: node_exporter
+    group: node_exporter
+    mode: "0755"
+
+- name: "Copy the node_exporter config file"
+  ansible.builtin.template:
+    src: node_exporter.conf.j2
+    dest: /etc/node_exporter.conf
+    mode: "0644"
+  notify: "Restart node_exporter"
+
+- name: "Copy the node_exporter systemd socket file"
+  ansible.builtin.template:
+    src: node_exporter.socket.j2
+    dest: /etc/systemd/system/node_exporter.socket
+    mode: "0644"
+  register: node_exporter_socket
+  notify: "Restart node_exporter"
+
+- name: "Copy the node_exporter systemd service file"
+  ansible.builtin.template:
+    src: node_exporter.service.j2
+    dest: /etc/systemd/system/node_exporter.service
+    mode: "0644"
+  register: node_exporter_service
+  notify: "Restart node_exporter"
+
+- name: "Reload systemd daemon if unit files changed"
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: "node_exporter_service is changed or node_exporter_socket is changed"
+
+- name: "Enable and start node_exporter service"
+  ansible.builtin.service:
+    name: node_exporter
+    state: started
+    enabled: true

--- a/roles/node_exporter/templates/node_exporter.conf.j2
+++ b/roles/node_exporter/templates/node_exporter.conf.j2
@@ -1,0 +1,1 @@
+OPTIONS="{{ node_exporter_options }}"

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Node Exporter
+Requires=node_exporter.socket
+
+[Service]
+User=node_exporter
+Group=node_exporter
+# Fallback when environment file does not exist
+Environment=OPTIONS=
+EnvironmentFile=-/etc/node_exporter.conf
+ExecStart={{ node_exporter_bin_path }}/node_exporter --web.systemd-socket $OPTIONS
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/node_exporter/templates/node_exporter.socket.j2
+++ b/roles/node_exporter/templates/node_exporter.socket.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Node Exporter
+
+[Socket]
+ListenStream={{ node_exporter_listen_port }}
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
# Description

## What it does

- Creates a dedicated system user/group `node_exporter` (no shell, no home)
- Downloads and installs node_exporter binary from GitHub releases (idempotent — skips if already installed)
- Deploys a systemd unit file via Jinja2 template
- Exposes metrics on port 9100 (configurable via `node_exporter_listen_address`)

## Variables

| Variable | Default | Description |
|---|---|---|
| `node_exporter_version` | `1.11.1` | Binary version to install |
| `node_exporter_bin_path` | `/usr/local/bin/node_exporter` | Installation path |
| `node_exporter_listen_address` | `0.0.0.0:9100` | Metrics listen address |
