### PR TITLE
chore: release 21.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ See the fragment files in the [changelog.d/ directory](./changelog.d).
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-21.1.1'></a>
+## 21.1.1 — 2026-06-11
+
+### Fixed
+
+- Bump the Helm chart to properly publish the Chart release.
+
 <a id='changelog-21.1.0'></a>
 ## 21.1.0 — 2026-06-11
 

--- a/charts/ansible-runner/Chart.yaml
+++ b/charts/ansible-runner/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ansible-runner
 description: Kubernetes jobs to execute ansible playbooks
 type: application
-version: 21.0.0
-appVersion: 21.0.0
+version: 21.1.1
+appVersion: 21.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas-ansible-utils"
-version = "21.1.0"
+version = "21.1.1"
 requires-python = ">=3.12"
 dependencies = [
 	"ansible",

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "atlas-ansible-utils"
-version = "21.1.0"
+version = "21.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
Properly bump the Helm chart to publish the release.